### PR TITLE
Add GH actions for crowdin automation

### DIFF
--- a/.github/workflows/download-translations.yml
+++ b/.github/workflows/download-translations.yml
@@ -1,0 +1,38 @@
+name: Crowdin Download Action
+
+on:
+  schedule:
+    # Run every day at 1 AM UTC
+    - cron: '0 1 * * *'
+  workflow_dispatch: # Manual triggering
+
+concurrency:
+  group: crowdin-download
+  cancel-in-progress: false
+
+permissions: write-all
+
+jobs:
+  crowdin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: draft
+
+      - name: Synchronize with Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n_crowdin_translations
+          create_pull_request: true
+          pull_request_title: 'New Crowdin translations'
+          pull_request_body: 'New Crowdin pull request with translations'
+          pull_request_base_branch_name: 'draft'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/hide-strings.yml
+++ b/.github/workflows/hide-strings.yml
@@ -1,0 +1,31 @@
+name: Crowdin Hide Strings
+
+on:
+  push:
+    paths: ["en/**/*.*"]
+    branches: [draft, master]
+
+jobs:
+  crowdin-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Crowdin CLI
+        run: |
+          curl -L https://github.com/crowdin/crowdin-cli/releases/latest/download/crowdin-cli.zip -o crowdin-cli.zip
+          unzip crowdin-cli.zip -d crowdin-cli
+          mkdir -p ~/bin
+          mv crowdin-cli/*/crowdin ~/bin/crowdin
+          cp crowdin-cli/*/crowdin-cli.jar ~/bin/crowdin-cli.jar
+          chmod +x ~/bin/crowdin
+          echo "PATH=$HOME/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Hide matching strings
+        run: |
+          crowdin --version
+          crowdin string list --verbose | grep -E -- '--- /no-print ---|--- no-print|--- print-only|hero_image images/' | awk '{print $1}' | tr -d '#' |
+          while read -r id; do
+            crowdin string edit "$id" --hidden
+          done
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/upload-sources.yml
+++ b/.github/workflows/upload-sources.yml
@@ -1,0 +1,23 @@
+name: Crowdin Upload Action
+
+on:
+  push:
+    paths: [ "en/**/*.*" ]
+    branches: [ draft, master ]
+
+jobs:
+  crowdin-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Crowdin push
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+        env:
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,4 +11,26 @@ For project materials and solutions, see [en/resources](https://github.com/raspb
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Licence
- See [LICENCE.md](LICENCE.md)
+See [LICENCE.md](LICENCE.md)
+
+## Crowdin setup
+
+To make use of the Github workflows in this project repository for automating translation setup, you need to add the project's Crowdin ID to the repository's secrets on Github.
+
+### Adding the project ID to Github
+
+1. Once the project is created on Crowdin, copy the project ID. 
+
+    - You should find this on the project's Crowdin dashboard, in a grey box on the right-hand side of the screen. It will be in the `Details` field, in the format `ID: 818746`. You just need the number.
+
+2. In the Github repository for the project, go to `Settings`, then `Secrets and variables` which is in the `Security` section.
+
+3. Click `Actions` and then go down to the `Repository secrets` section. 
+
+4. Click to add a `New repository secret`.
+
+5. **Enter the secret name, which should be `CROWDIN_PROJECT_ID`**
+
+6. Paste the project ID number into the `Secret` field.
+
+7. Press `Add secret` and you're done!

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,6 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+
 files:
   - source: /en/**/*.*
     translation: /%locale%/**/%original_file_name%


### PR DESCRIPTION
Related to sprint issue: https://github.com/RaspberryPiFoundation/digital-code-club/issues/908

This PR adds two Github workflows to projects created for Code Club:

- One automates the upload of translations from the `en` folder to Crowdin (any time changes are pushed to this folder).
- The other hides strings that match a regex pattern, using the Crowdin CLI (strings such as `--- no-print ---`.

Two env vars have been added to the `crowdin.yml` file to enable the GH actions to work, as well as instructions in the readme for how to set the repository keys that are needed.