### PR TITLE
Add nttt workflow

### DIFF
--- a/.github/workflows/hide-strings.yml
+++ b/.github/workflows/hide-strings.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Hide matching strings
         run: |
           crowdin --version
-          crowdin string list --verbose | grep -E -- '--- /no-print ---|--- no-print|--- print-only|hero_image images/' | awk '{print $1}' | tr -d '#' |
+          crowdin string list --verbose | grep -E -- '--- /no-print ---|--- no-print|--- print-only|hero_image images/' | awk '{print $1}' | sed 's/^#//' | grep '^[0-9]\+$'
           while read -r id; do
             crowdin string edit "$id" --hidden
           done

--- a/.github/workflows/nttt-processing.yml
+++ b/.github/workflows/nttt-processing.yml
@@ -1,0 +1,58 @@
+name: NTTT processing
+
+on:
+  # currently allowing manual trigger only
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to process translations on'
+        required: false
+        default: 'l10n_crowdin_translations'
+        type: string
+
+permissions: write-all
+
+jobs:
+  nttt-processing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch || 'l10n_crowdin_translations'}}
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11.0'
+      
+      - name: Install NTTT from GitHub repository
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://github.com/raspberrypilearning/nttt.git
+
+      - name: Run NTTT on all language directories except 'en'
+        run: |
+          for lang_dir in */; do
+            if [[ -d "$lang_dir" && "$lang_dir" != "en/" ]]; then
+              lang_code=$(basename "$lang_dir")
+              echo "Processing language: $lang_code"
+              cd "$lang_dir"
+              printf "y\n" | nttt -Y YES || true
+              cd ..
+            fi
+          done
+
+      - name: Add changes to branch
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action - NTTT Processing"
+          git add .
+          if git diff --staged --quiet; then
+            echo "No changes after NTTT processing"
+          else
+            git commit -m "Apply NTTT processing to translations"
+            git push origin HEAD:${{ inputs.branch || 'l10n_crowdin_translations'}}
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -10,3 +10,4 @@ files:
     ignore:
       - /en/**/*.pdf
       - /en/**/*.mp3
+      - /en/**/*.zip


### PR DESCRIPTION
## Changes
- Created new workflow for running NTTT script from its github repo
   - Tested on a test repo: https://github.com/raspberrypilearning/test-crowdin-post-processing
        - ✅  When the workflow manually triggered after downloading translations, it committed the NTTT fixes to the PR: https://github.com/raspberrypilearning/test-crowdin-post-processing/pull/24 
   - Confirmed with Sasha  
- Some minor fixes added
   - Failing hide strings workflow fixed
   - Added zip files to crowdin yml

## Future improvement
- There are more fixes that not covered by NTTT (eg. https://docs.google.com/document/d/1iHqgHTIlZoG7FdV14lMhHfLVRUvDjW8FOBYTbgIOAKM/edit?tab=t.0#bookmark=id.seh97xo5qk7s), which would be good handle either by updating NTTT or creating another script
-  Replacing NTTT entirely